### PR TITLE
FIx for Formatter crash

### DIFF
--- a/classes/Formatter.php
+++ b/classes/Formatter.php
@@ -25,8 +25,16 @@ class Formatter
     public static function renderDateFormat($value, $valtype) {
         
         $format = self::getDateFormatDisplay($valtype);
-        $date = date_create($value);
-        return date_format($date,$format);
+
+		//workaround for valtypes that return empty string from getDateFormatDisplay
+		if ($format == ''){
+			return $value;
+		}
+		else {
+			$date = date_create($value);
+			return date_format($date,$format);
+		}
+
     }
 
     /**


### PR DESCRIPTION
Had a problem with validation types other than the ones handlet in Formatter. This quick fix just returns the value if the format is returned empty. Empty format causes failure in datetime object creation and this results in "you have no access" error in dashboard.